### PR TITLE
Use the description to properly find the related auxiliary variables

### DIFF
--- a/tests/retrieve/test_adaptor.py
+++ b/tests/retrieve/test_adaptor.py
@@ -4,7 +4,7 @@ import pytest
 import xarray
 
 
-@pytest.mark.skip("API needs to be updated.")
+# @pytest.mark.skip("API needs to be updated.")
 def test_adaptor(tmp_path):
     """Full test with a local instance of the HTTP API."""
     from cads_adaptors import ObservationsAdaptor


### PR DESCRIPTION
Otherwise the "in" will make incorrect matches in some cases, like northward_wind_speed and wind_speed in IGRA.