### PR TITLE
Changes to remove the pandas warnings

### DIFF
--- a/cdsobs/ingestion/api.py
+++ b/cdsobs/ingestion/api.py
@@ -354,12 +354,17 @@ def _handle_aux_variables(
         )
     # Add quality flags
     if melt_columns.quality_flag is not None:
-        homogenised_data_melted["quality_flag"] = 3
+        na_quality_flag = 3
+        homogenised_data_melted["quality_flag"] = na_quality_flag
         for qf_col in melt_columns.quality_flag["quality_flag"]:
             var_mask = (
                 homogenised_data_melted["observed_variable"] == qf_col.main_variable
             )
-            var_quality_flag = homogenised_data_melted.loc[var_mask, qf_col.name]
+            var_quality_flag = (
+                homogenised_data_melted.loc[var_mask, qf_col.name]
+                .fillna(na_quality_flag)
+                .astype("int")
+            )
             homogenised_data_melted.loc[var_mask, "quality_flag"] = var_quality_flag
             homogenised_data_melted = homogenised_data_melted.drop(qf_col.name, axis=1)
             # Ensure is int and fill nans with 3 (missing according to the CDM)
@@ -368,12 +373,17 @@ def _handle_aux_variables(
         )
     # Add processing level
     if melt_columns.processing_level:
-        homogenised_data_melted["processing_level"] = 6
+        na_processing_level = 6
+        homogenised_data_melted["processing_level"] = na_processing_level
         for pl_col in melt_columns.processing_level["processing_level"]:
             var_mask = (
                 homogenised_data_melted["observed_variable"] == pl_col.main_variable
             )
-            var_processing_level = homogenised_data_melted.loc[var_mask, pl_col.name]
+            var_processing_level = (
+                homogenised_data_melted.loc[var_mask, pl_col.name]
+                .fillna(na_processing_level)
+                .astype("int")
+            )
             homogenised_data_melted.loc[
                 var_mask, "processing_level"
             ] = var_processing_level

--- a/cdsobs/ingestion/readers/cuon.py
+++ b/cdsobs/ingestion/readers/cuon.py
@@ -391,16 +391,16 @@ def fix_units(denormalized_table_file: pandas.DataFrame) -> pandas.DataFrame:
     relative_humidity_mask = (
         denormalized_table_file["observed_variable"] == relative_humidity_code
     )
-    denormalized_table_file["observation_value"].loc[relative_humidity_mask] *= 100
-    denormalized_table_file["uncertainty_value1"].loc[relative_humidity_mask] *= 100
-    denormalized_table_file["homogenisation_adjustment"].loc[
-        relative_humidity_mask
+    denormalized_table_file.loc[relative_humidity_mask, "observation_value"] *= 100
+    denormalized_table_file.loc[relative_humidity_mask, "uncertainty_value1"] *= 100
+    denormalized_table_file.loc[
+        relative_humidity_mask, "homogenisation_adjustment"
     ] *= 100
-    denormalized_table_file["units"].loc[
-        relative_humidity_mask
+    denormalized_table_file.loc[
+        relative_humidity_mask, "units"
     ] = relative_humidity_units_code
-    denormalized_table_file["uncertainty_units1"].loc[
-        relative_humidity_mask
+    denormalized_table_file.loc[
+        relative_humidity_mask, "uncertainty_units1"
     ] = relative_humidity_units_code
     # Geopotential, from J/kg (m2s2) to m
     geopotential_code = 117
@@ -409,11 +409,11 @@ def fix_units(denormalized_table_file: pandas.DataFrame) -> pandas.DataFrame:
     geopotential_mask = (
         denormalized_table_file["observed_variable"] == geopotential_code
     )
-    denormalized_table_file["observation_value"].loc[geopotential_mask] /= g
-    denormalized_table_file["uncertainty_value1"].loc[geopotential_mask] /= g
-    denormalized_table_file["units"].loc[geopotential_mask] = geopotential_units_code
-    denormalized_table_file["uncertainty_units1"].loc[
-        geopotential_mask
+    denormalized_table_file.loc[geopotential_mask, "observation_value"] /= g
+    denormalized_table_file.loc[geopotential_mask, "uncertainty_value1"] /= g
+    denormalized_table_file.loc[geopotential_mask, "units"] = geopotential_units_code
+    denormalized_table_file.loc[
+        geopotential_mask, "uncertainty_units1"
     ] = geopotential_units_code
     return denormalized_table_file
 

--- a/tests/retrieve/test_adaptor.py
+++ b/tests/retrieve/test_adaptor.py
@@ -4,7 +4,7 @@ import pytest
 import xarray
 
 
-# @pytest.mark.skip("API needs to be updated.")
+@pytest.mark.skip("Run by hand only.")
 def test_adaptor(tmp_path):
     """Full test with a local instance of the HTTP API."""
     from cads_adaptors import ObservationsAdaptor

--- a/tests/retrieve/test_adaptor.py
+++ b/tests/retrieve/test_adaptor.py
@@ -4,7 +4,7 @@ import pytest
 import xarray
 
 
-@pytest.mark.skip("API needs to be updated.")
+# @pytest.mark.skip("API needs to be updated.")
 def test_adaptor(tmp_path):
     """Full test with a local instance of the HTTP API."""
     from cads_adaptors import ObservationsAdaptor


### PR DESCRIPTION
This is to fix the pandas warnings:
- Some quality flag and processing_level have missing values, which disallow using integers, they are now filled with the integer value defined in the CDM for missing values.
- using `dataframe[column].loc[mask] = values` pattern raises the copy-on-write warning, the correct syntax is used now, with both labels inside of the loc[]: `dataframe.loc[mask, column] = values`